### PR TITLE
Fix nameclash function declaration

### DIFF
--- a/layout/default.php
+++ b/layout/default.php
@@ -55,7 +55,7 @@ if ($fluid) {
 
 $knownregionpost = $PAGE->blocks->is_known_region('side-post');
 
-$regions = bootstrap3_grid($hassidepost);
+$regions = theme_elegance_bootstrap3_grid($hassidepost);
 $PAGE->set_popup_notification_allowed(false);
 $PAGE->requires->jquery();
 

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -65,7 +65,7 @@ if ($fluid) {
 
 $knownregionpost = $PAGE->blocks->is_known_region('side-post');
 
-$regions = bootstrap3_grid($hassidepost);
+$regions = theme_elegance_bootstrap3_grid($hassidepost);
 $PAGE->set_popup_notification_allowed(false);
 $PAGE->requires->jquery();
 

--- a/layout/login.php
+++ b/layout/login.php
@@ -93,7 +93,7 @@ if ($show_instructions) {
     $columns = 'onecolumn';
 }
 
-$regions = bootstrap3_grid($hassidepost);
+$regions = theme_elegance_bootstrap3_grid($hassidepost);
 $PAGE->set_popup_notification_allowed(false);
 $PAGE->requires->jquery();
 

--- a/layout/maintenance.php
+++ b/layout/maintenance.php
@@ -24,7 +24,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$regions = bootstrap3_grid(false, false);
+$regions = theme_elegance_bootstrap3_grid(false, false);
 
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>

--- a/layout/my.php
+++ b/layout/my.php
@@ -56,7 +56,7 @@
 
             $knownregionpost = $PAGE->blocks->is_known_region('side-post');
 
-            $regions = bootstrap3_grid($hassidepost);
+            $regions = theme_elegance_bootstrap3_grid($hassidepost);
             $PAGE->set_popup_notification_allowed(false);
             $PAGE->requires->jquery();
 

--- a/lib.php
+++ b/lib.php
@@ -78,7 +78,7 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
   return $links;
 }
 
-function bootstrap3_grid($hassidepost) {
+function theme_elegance_bootstrap3_grid($hassidepost) {
 
         $regions = array('content' => 'col-sm-8 col-md-9');
         $regions['pre'] = 'empty';


### PR DESCRIPTION
bootstrap3_grid is used in every theme, causing nameclashes for every theme installed that uses it.
As there is no parent theme declaring this my commit resolves this by using the correct frankenstyle for the function.
