### PR TITLE
Assorted fixes for Moodle 2.9

### DIFF
--- a/lang/en/theme_elegance.php
+++ b/lang/en/theme_elegance.php
@@ -84,6 +84,7 @@ $string['region-side-pre'] = 'Left';
 
 $string['showoldmessages'] = 'Show Old Messages';
 $string['showoldmessagesdesc'] = 'Show old messages on the message menu.';
+$string['unreadnewnotification'] = 'New notification';
 
 $string['visibleadminonly'] = 'Blocks moved into the area below will only be seen by admins.';
 

--- a/less/styles.less
+++ b/less/styles.less
@@ -44,6 +44,7 @@ body.pagelayout-maintenance {
     background-image: url(@bodybg);
     background-repeat: no-repeat;
     background-position: fixed center center;
+    background-attachment: fixed;
     background-size: cover;
     margin-top: @navbarpadding;
 }

--- a/renderers/elegance_renderer.php
+++ b/renderers/elegance_renderer.php
@@ -511,7 +511,7 @@ class theme_elegance_widgets_renderer extends plugin_renderer_base {
         $messagecontent = new stdClass();
 
         if ($message->notification) {
-            $messagecontent->text = get_string('unreadnewnotification', 'message');
+            $messagecontent->text = get_string('unreadnewnotification', 'theme_elegance');
         } else {
             if ($message->fullmessageformat == FORMAT_HTML) {
                 $message->smallmessage = html_to_text($message->smallmessage);


### PR DESCRIPTION
This branch fixes 2 issues:
1. Prevents the background image from resizing when the user expands the navigation or administration tree.
2. Fixes a missing string notice when the user has unread messages.