### PR TITLE
Elegance: Fix calendar block styling

### DIFF
--- a/less/styles.less
+++ b/less/styles.less
@@ -526,6 +526,14 @@ table#user-grades th.userreport.c1 {
     border-radius: 4px;
 }
 
+.calendar_filters {
+    padding-left:21px;
+}
+
+.block .content h3.eventskey {
+    font-size: 14px;
+    margin-left: 0.5em;
+}
 
 /* @end */
 


### PR DESCRIPTION
Fixes for the calendar block:
1. Adds padding for the calendar event types
2. Adds padding to the event header
(See the photos below)
Before:
<img width="412" alt="elegance-before" src="https://cloud.githubusercontent.com/assets/1093550/10848667/72a282e6-7ef3-11e5-91e6-356c425ed26e.png">
After:
<img width="400" alt="elegance-after" src="https://cloud.githubusercontent.com/assets/1093550/10848672/77204678-7ef3-11e5-86c3-4934116ae3e5.png">

