### PR TITLE
Hide tree node items FA icons in RTL mode

### DIFF
--- a/less/elements/blocks.less
+++ b/less/elements/blocks.less
@@ -146,6 +146,7 @@
 
 .dir-rtl .collapsed .tree_item.branch:before { 
     content: " \f053";
+    display: none;
 }
 
 .dir-rtl .glyphicon-chevron-right:before {


### PR DESCRIPTION
Should fix https://github.com/bmbrands/moodle-theme_elegance/issues/157