### PR TITLE
Fix user picture of Forum pages

### DIFF
--- a/less/elements/forum.less
+++ b/less/elements/forum.less
@@ -49,21 +49,15 @@
             margin-bottom: 10px;
         }
         .row {
-            &.header {
-                min-height: 111px;
-            }
             .no-overflow {
                 margin-bottom: 0;
             }
             position: static;
             margin: 0;
             .left {
-                width: 110px;
                 padding: 0;
                 &.picture img {
-                    width: 100px;
-                    height: 100px;
-                    margin: 0;
+                    margin: 10px;
                     border: 1px solid #adc1de;
                     vertical-align: middle;
                 }
@@ -88,7 +82,7 @@
             }
             .topic {
                 overflow: auto;
-                margin-left: 100px;
+
                 .subject  {
                     padding-top: 6px;
                     color: @headings-color;

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -100,9 +100,6 @@ class theme_elegance_core_renderer extends theme_bootstrap_core_renderer {
 
     public function user_picture(stdClass $user, array $options = null) {
         global $PAGE;
-        if ($PAGE->bodyid == 'page-mod-forum-discuss' || $PAGE->bodyid == 'page-mod-forum-post' ) {
-            $options = array('size' => '100');
-        }
         if ($PAGE->bodyid == 'page-site-index' && isset($options['courseid'])) {
             $options = array('size' => '100');
         }


### PR DESCRIPTION
This pull request fixes the following:
1. Fixes the user picture when displayed on forum discussion pages (See #172)
2. Fixes the user profile picture on the actual posts (when viewing discussions) The reasoning for this change is the user profile picture is being scaled from 32px to 100px which is resulting in some images becoming distorted. (The display is now consistent with the bootstrap / clean / more see picture in #172)