### PR TITLE
Fix: Plugin overview page showed all versions as 0.1.2. #78

### DIFF
--- a/jquery/elegance.js
+++ b/jquery/elegance.js
@@ -17,7 +17,6 @@ $( document ).ready(function(){
     })
 
     $('body').show();
-    $('.version').text(NProgress.version);
     NProgress.start();
     setTimeout(function() { NProgress.done(); $('.fade').removeClass('out'); }, 1000);
 


### PR DESCRIPTION
The nprogress jQuery version function was being called with the effect that
any element with the class "version" was being set to "0.1.2".
https://github.com/bmbrands/moodle-theme_elegance/issues/78

I can't see that this function is required to use nprogress, the progress bar
appears to work fine without it, so removed this call which fixed the issue for
me.